### PR TITLE
Fix sleep() in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Usage Example
 
     while True:
         print("Temperature: %.2f degrees C"%tmp117.temperature)
-        sleep(1)
+        time.sleep(1)
 
 Contributing
 ============


### PR DESCRIPTION
change `sleep(1)` to `time.sleep(1)` to resolve "NameError: name 'sleep' is not defined"