### PR TITLE
Expose serial number

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Bryan Siepert for Adafruit Industries
+Copyright (c) 2020 Bryan Siepert for Adafruit Industries, and (c) 2021 Ian Grant
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/adafruit_tmp117.py
+++ b/adafruit_tmp117.py
@@ -13,12 +13,15 @@ parts based on SparkFun_TMP117_Arduino_Library by Madison Chodikov @ SparkFun El
 https://github.com/sparkfunX/Qwiic_TMP117
 https://github.com/sparkfun/SparkFun_TMP117_Arduino_Library
 
+Serial number register information:
+https://e2e.ti.com/support/sensors/f/1023/t/815716?TMP117-Reading-Serial-Number-from-EEPROM
+
 Implementation Notes
 --------------------
 
 **Hardware:**
 
-* `Adafruit TMP117 Breakout <https:#www.adafruit.com/product/PID_HERE>`_
+* `Adafruit TMP117 Breakout <https:#www.adafruit.com/product/4821>`_
 
 **Software and Dependencies:**
 
@@ -485,10 +488,7 @@ class TMP117:
 
     @property
     def serial_number(self):
-        """
-        48-bit factory-set unique ID
-        See: https://e2e.ti.com/support/sensors/f/1023/t/815716?TMP117-Reading-Serial-Number-from-EEPROM
-        """
+        """A 48-bit, factory-set unique identifier for the device."""
         eeprom1_data = bytearray(2)
         eeprom2_data = bytearray(2)
         eeprom3_data = bytearray(2)


### PR DESCRIPTION
According to the [TI datasheet](https://e2e.ti.com/support/sensors/f/1023/t/815716?TMP117-Reading-Serial-Number-from-EEPROM), a 48-bit unique identifier for the TMP117 is comprised of the `EEPROM1`, `EEPROM2` and `EEPROM3` registers.
This PR adds a method for exposing this value in the TMP117 interface. Unfortunately, I only have a single TMP117, so unable to verify that it gives a meaningful UUID for many sensors, but it certainly results in a stable number from my device.