### PR TITLE
Typo in function name

### DIFF
--- a/adafruit_tmp117.py
+++ b/adafruit_tmp117.py
@@ -459,7 +459,7 @@ class TMP117:
             raise AttributeError("measurement_delay must be a `MeasurementDelay`")
         self._raw_measurement_delay = value
 
-    def take_single_measurememt(self) -> float:
+    def take_single_measurement(self) -> float:
         """Perform a single measurement cycle respecting the value of `averaged_measurements`,
         returning the measurement once complete. Once finished the sensor is placed into a low power
         state until :py:meth:`take_single_measurement` or `temperature` are read.

--- a/examples/tmp117_single_measurement_test.py
+++ b/examples/tmp117_single_measurement_test.py
@@ -26,5 +26,5 @@ print(
 )
 
 while True:
-    print("Single measurement: %.2f degrees C" % tmp117.take_single_measurememt())
+    print("Single measurement: %.2f degrees C" % tmp117.take_single_measurement())
     # time.sleep(1)


### PR DESCRIPTION
I haven't tested this or run any unit tests. Worth checking to see if this typo crops up anywhere else.
thanks.