### PR TITLE
correcting One shot value according to datasheet

### DIFF
--- a/adafruit_tmp117.py
+++ b/adafruit_tmp117.py
@@ -162,7 +162,7 @@ class MeasurementMode(CV):
 MeasurementMode.add_values(
     (
         ("CONTINUOUS", 0, "Continuous", None),
-        ("ONE_SHOT", 2, "One shot", None),
+        ("ONE_SHOT", 3, "One shot", None),
         ("SHUTDOWN", 1, "Shutdown", None),
     )
 )


### PR DESCRIPTION
Small correction for the measurement_mode setter. 
according to the datasheet
![image](https://user-images.githubusercontent.com/34255413/222803716-cf4475c7-f0d1-478d-a570-69b67a7b929d.png)

I verify the Class name variable, and we are using the correct value in the Class variable
https://github.com/adafruit/Adafruit_CircuitPython_TMP117/blob/61b409809cd01c8a72c66670ab4ac78192f34f18/adafruit_tmp117.py#L76