### PR TITLE
memory_optimization

### DIFF
--- a/adafruit_tmp117.py
+++ b/adafruit_tmp117.py
@@ -260,17 +260,6 @@ class TMP117:
 
             tmp117 = adafruit_tmp117.TMP117(i2c)
 
-        In order to print information in a nicer way we create a dictionary with the
-        sensor information for the averaged measurements.
-
-        .. code-block::python3
-
-            Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERAGE_64X"}
-
-        We print the information for the Temperature sensor
-
-        .. code-block::python3
-
             # uncomment different options below to see how it affects the reported temperature
             # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_1X
             # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_8X
@@ -279,7 +268,7 @@ class TMP117:
 
             print(
                 "Number of averaged samples per measurement:",
-                Average_Measure[tmp117.averaged_measurements],
+                tmp117.averaged_measurements,
             )
             print("")
 
@@ -288,7 +277,15 @@ class TMP117:
                 time.sleep(0.1)
 
         """
-        return self._raw_averaged_measurements
+
+        average_measure = {
+            1: "AVERAGE_1X",
+            2: "AVERAGE_8X",
+            3: "AVERAGE_32X",
+            4: "AVERAGE_64X",
+        }
+
+        return average_measure[self._raw_averaged_measurements]
 
     @averaged_measurements.setter
     def averaged_measurements(self, value: int):
@@ -360,25 +357,6 @@ class TMP117:
 
             tmp117 = adafruit_tmp117.TMP117(i2c)
 
-        In order to print information in a nicer way, we create a dictionary with the
-        sensor information for the measurement delay.
-
-        .. code-block::python3
-
-            Delay_times = {
-                0: "DELAY_0_0015_S",
-                1: "DELAY_0_125_S",
-                2: "DELAY_0_250_S",
-                3: "DELAY_0_500_S",
-                4: "DELAY_1_S",
-                5: "DELAY_4_S",
-                6: "DELAY_8_S",
-                7: "DELAY_16_S",
-            }
-
-        We print the information for the Temperature sensor
-
-        .. code-block::python3
 
             # uncomment different options below to see how it affects the reported temperature
 
@@ -392,7 +370,7 @@ class TMP117:
             # tmp117.measurement_delay = adafruit_tmp117.DELAY_16_S
 
             print("Minimum time between measurements:",
-            Delay_times[tmp117.measurement_delay])
+            tmp117.measurement_delay)
 
             print("")
 
@@ -402,7 +380,18 @@ class TMP117:
 
         """
 
-        return self._raw_measurement_delay
+        delay_times = {
+            0: "DELAY_0_0015_S",
+            1: "DELAY_0_125_S",
+            2: "DELAY_0_250_S",
+            3: "DELAY_0_500_S",
+            4: "DELAY_1_S",
+            5: "DELAY_4_S",
+            6: "DELAY_8_S",
+            7: "DELAY_16_S",
+        }
+
+        return delay_times[self._raw_measurement_delay]
 
     @measurement_delay.setter
     def measurement_delay(self, value: int) -> None:

--- a/adafruit_tmp117.py
+++ b/adafruit_tmp117.py
@@ -56,7 +56,6 @@ except ImportError:
 __version__ = "0.0.0+auto.0"
 __repo__ = "https:#github.com/adafruit/Adafruit_CircuitPython_TMP117.git"
 
-
 _I2C_ADDR = 0x48  # default I2C Address
 _TEMP_RESULT = const(0x00)
 _CONFIGURATION = const(0x01)
@@ -97,7 +96,6 @@ DELAY_16_S = const(0b111)  # 16
 MEASUREMENTMODE_CONTINUOUS = const(0b00)
 MEASUREMENTMODE_ONE_SHOT = const(0b11)
 MEASUREMENTMODE_SHUTDOWN = const(0b01)
-
 
 AlertStatus = namedtuple("AlertStatus", ["high_alert", "low_alert"])
 

--- a/adafruit_tmp117.py
+++ b/adafruit_tmp117.py
@@ -149,7 +149,7 @@ class TMP117:
     def temperature(self):
         """The current measured temperature in degrees Celsius"""
 
-        return self._read_temperature()
+        return self._raw_temperature * _TMP117_RESOLUTION
 
     @property
     def temperature_offset(self):
@@ -260,6 +260,17 @@ class TMP117:
 
             tmp117 = adafruit_tmp117.TMP117(i2c)
 
+        In order to print information in a nicer way we create a dictionary with the
+        sensor information for the averaged measurements.
+
+        .. code-block::python3
+
+            Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERAGE_64X"}
+
+        We print the information for the Temperature sensor
+
+        .. code-block::python3
+
             # uncomment different options below to see how it affects the reported temperature
             # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_1X
             # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_8X
@@ -268,7 +279,7 @@ class TMP117:
 
             print(
                 "Number of averaged samples per measurement:",
-                tmp117.averaged_measurements,
+                Average_Measure[tmp117.averaged_measurements],
             )
             print("")
 
@@ -282,7 +293,7 @@ class TMP117:
     @averaged_measurements.setter
     def averaged_measurements(self, value: int):
         if value not in [0, 1, 2, 3]:
-            raise ValueError("averaged_measurements must be 0, 1, 2 or 3")
+            raise ValueError("averaged_measurements must be set to 0, 1, 2 or 3")
         self._raw_averaged_measurements = value
 
     @property
@@ -349,6 +360,26 @@ class TMP117:
 
             tmp117 = adafruit_tmp117.TMP117(i2c)
 
+        In order to print information in a nicer way, we create a dictionary with the
+        sensor information for the measurement delay.
+
+        .. code-block::python3
+
+            Delay_times = {
+                0: "DELAY_0_0015_S",
+                1: "DELAY_0_125_S",
+                2: "DELAY_0_250_S",
+                3: "DELAY_0_500_S",
+                4: "DELAY_1_S",
+                5: "DELAY_4_S",
+                6: "DELAY_8_S",
+                7: "DELAY_16_S",
+            }
+
+        We print the information for the Temperature sensor
+
+        .. code-block::python3
+
             # uncomment different options below to see how it affects the reported temperature
 
             # tmp117.measurement_delay = adafruit_tmp117.DELAY_0_0015_S
@@ -361,7 +392,7 @@ class TMP117:
             # tmp117.measurement_delay = adafruit_tmp117.DELAY_16_S
 
             print("Minimum time between measurements:",
-            tmp117.measurement_delay)
+            Delay_times[tmp117.measurement_delay])
 
             print("")
 
@@ -375,6 +406,10 @@ class TMP117:
 
     @measurement_delay.setter
     def measurement_delay(self, value: int) -> None:
+        if value not in [0, 1, 2, 3, 4, 5, 6, 7]:
+            raise ValueError(
+                "averaged_measurements must be set to 0, 1, 2, 3, 4, 5, 6, 7"
+            )
         self._raw_measurement_delay = value
 
     def take_single_measurement(self) -> float:
@@ -416,7 +451,7 @@ class TMP117:
 
         """
         if value not in [0, 1]:
-            raise ValueError("alert_mode must be an 0 or 1")
+            raise ValueError("alert_mode must be set to 0 or 1")
         self._raw_alert_mode = value
 
     @property
@@ -451,7 +486,7 @@ class TMP117:
         while not self._read_status()[2]:
             time.sleep(0.001)
 
-        return self._read_temperature()
+        return self._raw_temperature * _TMP117_RESOLUTION
 
     # eeprom write enable to set defaults for limits and config
     # requires context manager or something to perform a general call reset
@@ -465,9 +500,6 @@ class TMP117:
         data_ready = 0b001 & status_flags > 0
 
         return (high_alert, low_alert, data_ready)
-
-    def _read_temperature(self) -> float:
-        return self._raw_temperature * _TMP117_RESOLUTION
 
     # pylint: disable=no-self-use
     @staticmethod

--- a/adafruit_tmp117.py
+++ b/adafruit_tmp117.py
@@ -260,6 +260,17 @@ class TMP117:
 
             tmp117 = adafruit_tmp117.TMP117(i2c)
 
+        In order to print information in a nicer way we create a dictionary with the
+        sensor information for the averaged measurements.
+
+        .. code-block::python3
+
+            Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERAGE_64X"}
+
+        We print the information for the Temperature sensor
+
+        .. code-block::python3
+
             # uncomment different options below to see how it affects the reported temperature
             # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_1X
             # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_8X
@@ -268,7 +279,7 @@ class TMP117:
 
             print(
                 "Number of averaged samples per measurement:",
-                tmp117.averaged_measurements,
+                Average_Measure[tmp117.averaged_measurements],
             )
             print("")
 
@@ -277,15 +288,7 @@ class TMP117:
                 time.sleep(0.1)
 
         """
-
-        average_measure = {
-            1: "AVERAGE_1X",
-            2: "AVERAGE_8X",
-            3: "AVERAGE_32X",
-            4: "AVERAGE_64X",
-        }
-
-        return average_measure[self._raw_averaged_measurements]
+        return self._raw_averaged_measurements
 
     @averaged_measurements.setter
     def averaged_measurements(self, value: int):
@@ -357,6 +360,25 @@ class TMP117:
 
             tmp117 = adafruit_tmp117.TMP117(i2c)
 
+        In order to print information in a nicer way, we create a dictionary with the
+        sensor information for the measurement delay.
+
+        .. code-block::python3
+
+            Delay_times = {
+                0: "DELAY_0_0015_S",
+                1: "DELAY_0_125_S",
+                2: "DELAY_0_250_S",
+                3: "DELAY_0_500_S",
+                4: "DELAY_1_S",
+                5: "DELAY_4_S",
+                6: "DELAY_8_S",
+                7: "DELAY_16_S",
+            }
+
+        We print the information for the Temperature sensor
+
+        .. code-block::python3
 
             # uncomment different options below to see how it affects the reported temperature
 
@@ -370,7 +392,7 @@ class TMP117:
             # tmp117.measurement_delay = adafruit_tmp117.DELAY_16_S
 
             print("Minimum time between measurements:",
-            tmp117.measurement_delay)
+            Delay_times[tmp117.measurement_delay])
 
             print("")
 
@@ -380,18 +402,7 @@ class TMP117:
 
         """
 
-        delay_times = {
-            0: "DELAY_0_0015_S",
-            1: "DELAY_0_125_S",
-            2: "DELAY_0_250_S",
-            3: "DELAY_0_500_S",
-            4: "DELAY_1_S",
-            5: "DELAY_4_S",
-            6: "DELAY_8_S",
-            7: "DELAY_16_S",
-        }
-
-        return delay_times[self._raw_measurement_delay]
+        return self._raw_measurement_delay
 
     @measurement_delay.setter
     def measurement_delay(self, value: int) -> None:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,9 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["adafruit_register",]
+autodoc_mock_imports = [
+    "adafruit_register",
+]
 
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,9 +26,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = [
-    "adafruit_register",
-]
+# autodoc_mock_imports = ["adafruit_register",]
 
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-# autodoc_mock_imports = ["adafruit_register",]
+autodoc_mock_imports = ["adafruit_register",]
 
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["adafruit_register",]
+autodoc_mock_imports = ["adafruit_register"]
 
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-# autodoc_mock_imports = ["digitalio", "busio"]
+autodoc_mock_imports = ["adafruit_register",]
 
 
 intersphinx_mapping = {

--- a/examples/tmp117_limits_test.py
+++ b/examples/tmp117_limits_test.py
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: Unlicense
 import time
 import board
-from adafruit_tmp117 import TMP117, AlertMode
+import adafruit_tmp117
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
 
-tmp117 = TMP117(i2c)
+tmp117 = adafruit_tmp117.TMP117(i2c)
 
 tmp117.high_limit = 25
 tmp117.low_limit = 10
@@ -17,10 +17,10 @@ print("\nHigh limit", tmp117.high_limit)
 print("Low limit", tmp117.low_limit)
 
 # Try changing `alert_mode`  to see how it modifies the behavior of the alerts.
-# tmp117.alert_mode = AlertMode.WINDOW #default
-# tmp117.alert_mode = AlertMode.HYSTERESIS
+# tmp117.alert_mode = adafruit_tmp117.ALERT_WINDOW  #default
+# tmp117.alert_mode = adafruit_tmp117.ALERT_HYSTERESIS
 
-print("Alert mode:", AlertMode.string[tmp117.alert_mode])
+print("Alert mode:", tmp117.alert_mode)
 print("\n\n")
 while True:
     print("Temperature: %.2f degrees C" % tmp117.temperature)

--- a/examples/tmp117_rate_and_averaging_test.py
+++ b/examples/tmp117_rate_and_averaging_test.py
@@ -15,19 +15,6 @@ i2c = board.I2C()  # uses board.SCL and board.SDA
 tmp117 = adafruit_tmp117.TMP117(i2c)
 
 
-# Values here for the average_measurements and measurement_delay
-Delay_times = {
-    0: "DELAY_0_0015_S",
-    1: "DELAY_0_125_S",
-    2: "DELAY_0_250_S",
-    3: "DELAY_0_500_S",
-    4: "DELAY_1_S",
-    5: "DELAY_4_S",
-    6: "DELAY_8_S",
-    7: "DELAY_16_S",
-}
-Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERAGE_64X"}
-
 # uncomment different options below to see how it affects the reported temperature
 # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_1X
 # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_8X
@@ -45,9 +32,9 @@ Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERA
 
 print(
     "Number of averaged samples per measurement:",
-    Average_Measure[tmp117.averaged_measurements],
+    tmp117.averaged_measurements,
 )
-print("Minimum time between measurements:", Delay_times[tmp117.measurement_delay])
+print("Minimum time between measurements:", tmp117.measurement_delay)
 print("")
 
 while True:

--- a/examples/tmp117_rate_and_averaging_test.py
+++ b/examples/tmp117_rate_and_averaging_test.py
@@ -15,6 +15,19 @@ i2c = board.I2C()  # uses board.SCL and board.SDA
 tmp117 = adafruit_tmp117.TMP117(i2c)
 
 
+# Values here for the average_measurements and measurement_delay
+Delay_times = {
+    0: "DELAY_0_0015_S",
+    1: "DELAY_0_125_S",
+    2: "DELAY_0_250_S",
+    3: "DELAY_0_500_S",
+    4: "DELAY_1_S",
+    5: "DELAY_4_S",
+    6: "DELAY_8_S",
+    7: "DELAY_16_S",
+}
+Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERAGE_64X"}
+
 # uncomment different options below to see how it affects the reported temperature
 # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_1X
 # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_8X
@@ -32,9 +45,9 @@ tmp117 = adafruit_tmp117.TMP117(i2c)
 
 print(
     "Number of averaged samples per measurement:",
-    tmp117.averaged_measurements,
+    Average_Measure[tmp117.averaged_measurements],
 )
-print("Minimum time between measurements:", tmp117.measurement_delay)
+print("Minimum time between measurements:", Delay_times[tmp117.measurement_delay])
 print("")
 
 while True:

--- a/examples/tmp117_rate_and_averaging_test.py
+++ b/examples/tmp117_rate_and_averaging_test.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2020 Bryan Siepert, written for Adafruit Industries
+# SPDX-FileCopyrightText: 2023 Jose David Montoya
 #
 # SPDX-License-Identifier: Unlicense
 # pylint:disable=no-member
@@ -12,6 +13,20 @@ import adafruit_tmp117
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
 tmp117 = adafruit_tmp117.TMP117(i2c)
+
+
+# Values here for the average_measurements and measurement_delay
+Delay_times = {
+    0: "DELAY_0_0015_S",
+    1: "DELAY_0_125_S",
+    2: "DELAY_0_250_S",
+    3: "DELAY_0_500_S",
+    4: "DELAY_1_S",
+    5: "DELAY_4_S",
+    6: "DELAY_8_S",
+    7: "DELAY_16_S",
+}
+Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERAGE_64X"}
 
 # uncomment different options below to see how it affects the reported temperature
 # tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_1X
@@ -30,9 +45,9 @@ tmp117 = adafruit_tmp117.TMP117(i2c)
 
 print(
     "Number of averaged samples per measurement:",
-    tmp117.averaged_measurements,
+    Average_Measure[tmp117.averaged_measurements],
 )
-print("Minimum time between measurements:", tmp117.measurement_delay)
+print("Minimum time between measurements:", Delay_times[tmp117.measurement_delay])
 print("")
 
 while True:

--- a/examples/tmp117_rate_and_averaging_test.py
+++ b/examples/tmp117_rate_and_averaging_test.py
@@ -7,38 +7,34 @@
 # such as the one built into the Mu editor.
 import time
 import board
-from adafruit_tmp117 import TMP117, AverageCount, MeasurementDelay
+import adafruit_tmp117
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-tmp117 = TMP117(i2c)
+tmp117 = adafruit_tmp117.TMP117(i2c)
 
 # uncomment different options below to see how it affects the reported temperature
-# tmp117.averaged_measurements = AverageCount.AVERAGE_1X
-# tmp117.averaged_measurements = AverageCount.AVERAGE_8X
-# tmp117.averaged_measurements = AverageCount.AVERAGE_32X
-# tmp117.averaged_measurements = AverageCount.AVERAGE_64X
+# tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_1X
+# tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_8X
+# tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_32X
+# tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_64X
 
-# tmp117.measurement_delay = MeasurementDelay.DELAY_0_0015_S
-# tmp117.measurement_delay = MeasurementDelay.DELAY_0_125_S
-# tmp117.measurement_delay = MeasurementDelay.DELAY_0_250_S
-# tmp117.measurement_delay = MeasurementDelay.DELAY_0_500_S
-# tmp117.measurement_delay = MeasurementDelay.DELAY_1_S
-# tmp117.measurement_delay = MeasurementDelay.DELAY_4_S
-# tmp117.measurement_delay = MeasurementDelay.DELAY_8_S
-# tmp117.measurement_delay = MeasurementDelay.DELAY_16_S
+# tmp117.measurement_delay = adafruit_tmp117.DELAY_0_0015_S
+# tmp117.measurement_delay = adafruit_tmp117.DELAY_0_125_S
+# tmp117.measurement_delay = adafruit_tmp117.DELAY_0_250_S
+# tmp117.measurement_delay = adafruit_tmp117.DELAY_0_500_S
+# tmp117.measurement_delay = adafruit_tmp117.DELAY_1_S
+# tmp117.measurement_delay = adafruit_tmp117.DELAY_4_S
+# tmp117.measurement_delay = adafruit_tmp117.DELAY_8_S
+# tmp117.measurement_delay = adafruit_tmp117.DELAY_16_S
 
 print(
     "Number of averaged samples per measurement:",
-    AverageCount.string[tmp117.averaged_measurements],
+    tmp117.averaged_measurements,
 )
-print(
-    "Minimum time between measurements:",
-    MeasurementDelay.string[tmp117.measurement_delay],
-    "seconds",
-)
+print("Minimum time between measurements:", tmp117.measurement_delay)
 print("")
 
 while True:
     print("Temperature:", tmp117.temperature)
-    time.sleep(0.01)
+    time.sleep(1)

--- a/examples/tmp117_single_measurement_test.py
+++ b/examples/tmp117_single_measurement_test.py
@@ -21,7 +21,7 @@ Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERA
 
 print(
     "Number of averaged samples per measurement:",
-    Average_Measure[tmp117.averaged_measurements],
+    tmp117.averaged_measurements,
 )
 
 while True:

--- a/examples/tmp117_single_measurement_test.py
+++ b/examples/tmp117_single_measurement_test.py
@@ -2,28 +2,23 @@
 #
 # SPDX-License-Identifier: Unlicense
 import board
-from adafruit_tmp117 import TMP117, AverageCount
+import adafruit_tmp117
 
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-tmp117 = TMP117(i2c)
+tmp117 = adafruit_tmp117.TMP117(i2c)
 
 # uncomment different options below to see how it affects the reported temperature
 # and measurement time
 
-# tmp117.averaged_measurements = AverageCount.AVERAGE_1X
-# tmp117.averaged_measurements = AverageCount.AVERAGE_8X
-# tmp117.averaged_measurements = AverageCount.AVERAGE_32X
-# tmp117.averaged_measurements = AverageCount.AVERAGE_64X
+# tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_1X
+# tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_8X
+# tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_32X
+# tmp117.averaged_measurements = adafruit_tmp117.AVERAGE_64X
 
 print(
     "Number of averaged samples per measurement:",
-    AverageCount.string[tmp117.averaged_measurements],
-)
-print(
-    "Reads should take approximately",
-    AverageCount.string[tmp117.averaged_measurements] * 0.0155,
-    "seconds",
+    tmp117.averaged_measurements,
 )
 
 while True:

--- a/examples/tmp117_single_measurement_test.py
+++ b/examples/tmp117_single_measurement_test.py
@@ -8,6 +8,9 @@ i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
 tmp117 = adafruit_tmp117.TMP117(i2c)
 
+# Values here for the average_measurements
+Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERAGE_64X"}
+
 # uncomment different options below to see how it affects the reported temperature
 # and measurement time
 
@@ -18,7 +21,7 @@ tmp117 = adafruit_tmp117.TMP117(i2c)
 
 print(
     "Number of averaged samples per measurement:",
-    tmp117.averaged_measurements,
+    Average_Measure[tmp117.averaged_measurements],
 )
 
 while True:

--- a/examples/tmp117_single_measurement_test.py
+++ b/examples/tmp117_single_measurement_test.py
@@ -21,7 +21,7 @@ Average_Measure = {1: "AVERAGE_1X", 2: "AVERAGE_8X", 3: "AVERAGE_32X", 4: "AVERA
 
 print(
     "Number of averaged samples per measurement:",
-    tmp117.averaged_measurements,
+    Average_Measure[tmp117.averaged_measurements],
 )
 
 while True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,3 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
-adafruit-circuitpython-register
-adafruit-circuitpython-busdevice


### PR DESCRIPTION
For a QT PY M0, you must use the mpy file. closes #11 

These are breaking changes. Learning Guide probably need updating.

Tested with examples.
Initial test code:

```python

# SPDX-FileCopyrightText: 2023 Jose D. Montoya
#
# SPDX-License-Identifier: Unlicense

"""
TMP117 Properties Test
"""
import time
import board
import adafruit_tmp117

i2c = board.I2C()  # uses board.SCL and board.SDA
# i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
tmp117 = adafruit_tmp117.TMP117(i2c)
alert_status = tmp117.alert_status
while True:
    print("My ID:", tmp117._part_id)
    print("My Serial Numer: ", tmp117.serial_number)
    print("Temperature Offset: ", tmp117.temperature_offset)
    print("High Limit: ", tmp117.high_limit)
    print("Low Limit: ", tmp117.low_limit)
    print("Alert status: ", tmp117.alert_status)
    print("High alert:", alert_status.high_alert)
    print("Low alert:", alert_status.low_alert)
    print("Averaged Measurements: ", tmp117.averaged_measurements)
    print("Measurement Mode: ", tmp117.measurement_mode)
    print("Measurement Delay: ", tmp117.measurement_delay)
    print("Alert Mode: ", tmp117.alert_mode)
    print("Temperature: %.2f degrees C" % tmp117.temperature)
    time.sleep(1)

```

### Results

```python
Adafruit CircuitPython 8.0.4 on 2023-03-15; Adafruit QT Py M0 with samd21e18
>>> import tb
My ID: 279
My Serial Numer:  bytearray(b'\x0co\x0fpG\xa4')
Temperature Offset:  0.0
High Limit:  192.0
Low Limit:  -256.0
Alert status:  AlertStatus(high_alert=False, low_alert=False)
High alert: False
Low alert: False
Averaged Measurements:  1
Measurement Mode:  0
Measurement Delay:  4
Alert Mode:  False
Temperature: 19.52 degrees C
```


